### PR TITLE
Add Metal backend examples

### DIFF
--- a/metal/README.md
+++ b/metal/README.md
@@ -1,0 +1,16 @@
+# Metal Backend Examples
+
+This directory contains end-to-end examples for running models on ExecuTorch Metal backend.
+
+## Prerequisites
+
+- macOS with Apple Silicon (M1/M2/M3/M4)
+- Conda environment manager
+
+## Voxtral Example
+
+See the [Voxtral Metal Backend example](voxtral/README.md).
+
+## Whisper Example
+
+See the [Whisper Metal Backend example](whisper/README.md).

--- a/metal/setup_python_env.sh
+++ b/metal/setup_python_env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Check if we're in the executorch directory
+if [ "$(basename "$(pwd)")" != "executorch" ]; then
+  echo "Error: Not in executorch directory"
+  echo "Current directory: $(pwd)"
+  echo "Please navigate to the executorch directory"
+  exit 1
+fi
+
+if [ ! -f "pyproject.toml" ] || [ ! -d "backends" ] || [ ! -f "install_executorch.sh" ]; then
+  echo "Error: executorch directory structure is incomplete"
+  exit 1
+fi
+
+# Install Optimum-ExecuTorch
+export OPTIMUM_ET_VERSION=$(cat .ci/docker/ci_commit_pins/optimum-executorch.txt)
+
+echo "Installing Optimum-ExecuTorch version: $OPTIMUM_ET_VERSION"
+pip install git+https://github.com/huggingface/optimum-executorch.git@${OPTIMUM_ET_VERSION}
+
+# Install required libraries
+echo "Installing required libraries"
+pip install mistral-common librosa accelerate
+
+# Install ExecuTorch
+echo "Installing ExecuTorch"
+./install_executorch.sh

--- a/metal/voxtral/README.md
+++ b/metal/voxtral/README.md
@@ -1,0 +1,120 @@
+# Voxtral Metal Backend Example
+
+This directory contains an end-to-end example for running Voxtral on ExecuTorch Metal backend.
+
+## Prerequisites
+
+- macOS with Apple Silicon (M1/M2/M3/M4)
+- Conda environment manager
+
+## Getting the scripts
+
+Start by cloning the `executorch-examples` repo, in order to get the scripts:
+
+```bash
+git clone git@github.com:meta-pytorch/executorch-examples.git
+cd executorch-examples
+```
+
+The Metal backend scripts are located under `metal/`
+
+## Voxtral Example
+
+The Voxtral example demonstrates how to:
+1. Set up your environment
+2. Export the Mistral Voxtral model to ExecuTorch format
+3. Build the Voxtral Metal runner
+4. Run inference on audio input
+
+**Run Voxtral end-to-end:**
+
+```bash
+metal/voxtral/e2e.sh \
+  --artifact-dir <artifact_dir> \
+  --env-name <env_name> \
+  --clone-et \
+  --create-env \
+  --setup-env \
+  --export \
+  --build \
+  --run --audio-path <audio_path>
+```
+
+**Required Arguments:**
+
+- `<artifact_dir>` - Directory to store artifacts (e.g., `~/Desktop/voxtral`)
+- `<env_name>` - Name of the conda environment to create (e.g., `voxtral-example`)
+- `<audio_path>` - Path to your audio file for inference (e.g., `~/Desktop/audio.wav`)
+
+**Example:**
+
+```bash
+metal/voxtral/e2e.sh \
+  --artifact-dir ~/Desktop/voxtral \
+  --env-name voxtral-example \
+  --clone-et \
+  --create-env \
+  --setup-env \
+  --export \
+  --build \
+  --run --audio-path ~/Desktop/audio.wav
+```
+
+This will automatically:
+1. Setup the environment:
+  - Clone the executorch repo
+  - Create a conda environment named `voxtral-example`
+  - Install all dependencies
+2. Export the Voxtral model to the `~/Desktop/voxtral` directory
+3. Build the Voxtral Metal runner
+4. Run inference on `~/Desktop/voxtral/audio.wav`
+
+### Step-by-Step Manual Process
+
+If you prefer to run each step individually, follow these steps:
+
+#### Step 1: Set up the environment
+
+```bash
+git clone git@github.com:pytorch/executorch.git
+cd executorch
+conda create -yn <env_name> python=3.11
+conda activate <env_name>
+/path/to/metal/setup_python_env.sh
+```
+
+#### Step 2: Export the Model
+
+```bash
+/path/to/metal/voxtral/export.sh <artifact_dir>
+```
+
+**Arguments:**
+- `<artifact_dir>` - Directory to store exported model files (e.g., `~/Desktop/voxtral`)
+
+This will:
+- Download the Mistral Voxtral model
+- Export it to ExecuTorch format with Metal optimizations
+- Save model files (`.pte`), metadata, and preprocessor to the specified directory
+
+#### Step 3: Build the Voxtral Metal Runner
+
+```bash
+/path/to/metal/voxtral/build.sh
+```
+
+#### Step 4: Run Inference
+
+```bash
+/path/to/metal/voxtral/run.sh <audio_path> <artifact_dir>
+```
+
+**Arguments:**
+- `<audio_path>` - Path to your audio file (e.g., `/path/to/audio.wav`)
+- `<artifact_dir>` - Directory containing exported model files (e.g., `~/Desktop/voxtral`)
+
+This will:
+- Validate that all required model files exist
+- Load the model and preprocessor
+- Run inference on the provided audio
+- Display timing information

--- a/metal/voxtral/build.sh
+++ b/metal/voxtral/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake --preset llm \
+              -DEXECUTORCH_BUILD_METAL=ON \
+              -DCMAKE_INSTALL_PREFIX=cmake-out \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DEXECUTORCH_ENABLE_LOGGING=ON \
+              -DEXECUTORCH_LOG_LEVEL=Info \
+              -Bcmake-out -S.
+
+cmake --build cmake-out -j16 --target install --config Release
+
+cmake -DEXECUTORCH_BUILD_METAL=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -Sexamples/models/voxtral \
+      -Bcmake-out/examples/models/voxtral/
+
+cmake --build cmake-out/examples/models/voxtral --target voxtral_runner --config Release

--- a/metal/voxtral/e2e.sh
+++ b/metal/voxtral/e2e.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+# Initialize variables
+CLONE=false
+CREATE_ENV=false
+SETUP_ENV=false
+EXPORT=false
+BUILD=false
+RUN=false
+EXECUTORCH_PATH=""
+ARTIFACT_DIR=""
+ENV_NAME=""
+AUDIO_PATH=""
+
+echo "Current script path: $(realpath "$0")"
+SCRIPT_DIR="$(realpath "$(dirname "$(realpath "$0")")")"
+echo "Scripts directory: $SCRIPT_DIR"
+SCRIPT_PARENT="$(realpath "$SCRIPT_DIR/..")"
+echo "Scripts parent: $SCRIPT_PARENT"
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  --artifact-dir DIR     Path to the directory were artifacts will be placed (required)"
+  echo "  --env-name NAME        Name of the conda environment (required)"
+  echo "  --clone-et             Clone the executorch repository"
+  echo "  --executorch-path DIR  Path to the executorch repo (required if --clone-et not used)"
+  echo "  --create-env           Create the Python environment"
+  echo "  --setup-env            Set up the Python environment"
+  echo "  --export               Export the Voxtral model"
+  echo "  --build                Build the Voxtral runner"
+  echo "  --audio-path PATH      Path to the input audio file"
+  echo "  --run                  Run the Voxtral model"
+  echo "  -h, --help             Display this help message"
+  echo ""
+  echo "Example:"
+  echo "  $0 --env-name metal-backend --setup-env --export --build --audio-path audio.wav --run"
+  exit 1
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --clone-et)
+      CLONE=true
+      shift
+      ;;
+    --executorch-path)
+      EXECUTORCH_PATH="$2"
+      shift 2
+      ;;
+    --env-name)
+      ENV_NAME="$2"
+      shift 2
+      ;;
+    --create-env)
+      CREATE_ENV=true
+      shift
+      ;;
+    --setup-env)
+      SETUP_ENV=true
+      shift
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="$2"
+      shift 2
+      ;;
+    --export)
+      EXPORT=true
+      shift
+      ;;
+    --build)
+      BUILD=true
+      shift
+      ;;
+    --audio-path)
+      AUDIO_PATH="$2"
+      shift 2
+      ;;
+    --run)
+      RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Error: Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Validate required options
+if [ -z "$ARTIFACT_DIR" ]; then
+  echo "Error: --artifact-dir is required"
+  exit 1
+fi
+
+if [ -z "$ENV_NAME" ]; then
+  echo "Error: --env-name is required"
+  exit 1
+fi
+
+if [ "$CLONE" = false ]; then
+  if [ -z "$EXECUTORCH_PATH" ]; then
+    echo "Error: --executorch-path is required when not using --clone"
+    exit 1
+  fi
+fi
+
+if [ "$RUN" = true ]; then
+  if [ -z "$AUDIO_PATH" ]; then
+    echo "Error: --audio-path is required when using --run"
+    exit 1
+  fi
+fi
+
+# Clone and cd into executorch if --clone flag is set
+if [ "$CLONE" = true ]; then
+  if [ -n "$EXECUTORCH_PATH" ]; then
+    echo "Error: --executorch-path should not be provided when using --clone"
+    exit 1
+  fi
+
+  mkdir -p "$ARTIFACT_DIR"
+  cd "$ARTIFACT_DIR"
+  echo "Cloning executorch repository..."
+  git clone git@github.com:pytorch/executorch.git
+
+  # Set EXECUTORCH_PATH to ARTIFACT_DIR/executorch after cloning
+  EXECUTORCH_PATH="${ARTIFACT_DIR}/executorch"
+fi
+
+cd "$EXECUTORCH_PATH"
+
+# Execute create-env
+if [ "$CREATE_ENV" = true ]; then
+  echo "Creating the Python environment $ENV_NAME ..."
+  conda create -yn "$ENV_NAME" python=3.11
+fi
+
+# Execute setup-env
+if [ "$SETUP_ENV" = true ]; then
+  echo "Setting up Python environment $ENV_NAME ..."
+  echo " - Script: $SCRIPT_PARENT/setup_python_env.sh"
+  conda run -n "$ENV_NAME" "$SCRIPT_PARENT/setup_python_env.sh"
+
+fi
+
+# Execute export
+if [ "$EXPORT" = true ]; then
+  echo "Exporting Voxtral model to $ARTIFACT_DIR ..."
+  echo " - Script: $SCRIPT_DIR/export.sh"
+  conda run -n "$ENV_NAME" "$SCRIPT_DIR/export.sh" "$ARTIFACT_DIR"
+fi
+
+# Execute build
+if [ "$BUILD" = true ]; then
+  echo "Building Voxtral runner ..."
+  echo " - Script: $SCRIPT_DIR/build.sh"
+  conda run -n "$ENV_NAME" "$SCRIPT_DIR/build.sh"
+fi
+
+# Execute run
+if [ "$RUN" = true ]; then
+  echo "Running Voxtral with audio: $AUDIO_PATH"
+  echo " - Script: $SCRIPT_DIR/run.sh"
+  "$SCRIPT_DIR/run.sh" "$AUDIO_PATH" "$ARTIFACT_DIR"
+fi
+
+echo "Done!"

--- a/metal/voxtral/export.sh
+++ b/metal/voxtral/export.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+ARTIFACT_DIR="$1"
+
+if [ -z "$ARTIFACT_DIR" ]; then
+    echo "Error: ARTIFACT_DIR argument not provided."
+    echo "Usage: $0 <ARTIFACT_DIR>"
+    exit 1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+optimum-cli export executorch \
+            --model "mistralai/Voxtral-Mini-3B-2507" \
+            --task "multimodal-text-to-text" \
+            --recipe "metal" \
+            --dtype bfloat16 \
+            --max_seq_len 1024 \
+            --output_dir "$ARTIFACT_DIR"
+
+python -m executorch.extension.audio.mel_spectrogram \
+            --feature_size 128 \
+            --stack_output \
+            --max_audio_len 300 \
+            --output_file "$ARTIFACT_DIR"/voxtral_preprocessor.pte
+
+curl -L https://huggingface.co/mistralai/Voxtral-Mini-3B-2507/resolve/main/tekken.json -o "$ARTIFACT_DIR"/tekken.json

--- a/metal/voxtral/run.sh
+++ b/metal/voxtral/run.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Error: Input audio path and artifact directory path must be provided as arguments"
+  echo "Usage: $0 <input_audio_path> <artifact_dir>"
+  echo ""
+  echo "Arguments:"
+  echo "  <input_audio_path>  Path to the input audio file"
+  echo "  <artifact_dir>      Path to directory containing model files"
+  exit 1
+fi
+
+INPUT_AUDIO_PATH="$1"
+ARTIFACT_DIR="$2"
+
+# Check if input audio file exists
+if [ ! -f "$INPUT_AUDIO_PATH" ]; then
+  echo "Error: Input audio file not found: $INPUT_AUDIO_PATH"
+  exit 1
+fi
+
+# Check if directory exists
+if [ ! -d "$ARTIFACT_DIR" ]; then
+  echo "Error: Directory not found: $ARTIFACT_DIR"
+  exit 1
+fi
+
+# Check for required files
+REQUIRED_FILES=("model.pte" "aoti_metal_blob.ptd" "tekken.json" "voxtral_preprocessor.pte")
+for file in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$ARTIFACT_DIR/$file" ]; then
+    echo "Error: Required file not found: $ARTIFACT_DIR/$file"
+    exit 1
+  fi
+done
+
+/usr/bin/time -l ./cmake-out/examples/models/voxtral/voxtral_runner \
+      --model_path "$ARTIFACT_DIR"/model.pte \
+      --data_path "$ARTIFACT_DIR"/aoti_metal_blob.ptd \
+      --tokenizer_path "$ARTIFACT_DIR"/tekken.json \
+      --audio_path "$INPUT_AUDIO_PATH" \
+      --processor_path "$ARTIFACT_DIR"/voxtral_preprocessor.pte \
+      --temperature 0

--- a/metal/whisper/README.md
+++ b/metal/whisper/README.md
@@ -1,0 +1,120 @@
+# Whisper Metal Backend Example
+
+This directory contains an end-to-end example for running Whisper on ExecuTorch Metal backend.
+
+## Prerequisites
+
+- macOS with Apple Silicon (M1/M2/M3/M4)
+- Conda environment manager
+
+## Getting the scripts
+
+Start by cloning the `executorch-examples` repo, in order to get the scripts:
+
+```bash
+git clone git@github.com:meta-pytorch/executorch-examples.git
+cd executorch-examples
+```
+
+The Metal backend scripts are located under `metal/`
+
+## Whisper Example
+
+The Whisper example demonstrates how to:
+1. Set up your environment
+2. Export the Whisper model to ExecuTorch format
+3. Build the Whisper Metal runner
+4. Run inference on audio input
+
+**Run Whisper end-to-end:**
+
+```bash
+metal/whisper/e2e.sh \
+  --artifact-dir <artifact_dir> \
+  --env-name <env_name> \
+  --clone-et \
+  --create-env \
+  --setup-env \
+  --export \
+  --build \
+  --run --audio-path <audio_path>
+```
+
+**Required Arguments:**
+
+- `<artifact_dir>` - Directory to store artifacts (e.g., `~/Desktop/whisper`)
+- `<env_name>` - Name of the conda environment to create (e.g., `whisper-example`)
+- `<audio_path>` - Path to your audio file for inference (e.g., `~/Desktop/audio.wav`)
+
+**Example:**
+
+```bash
+metal/whisper/e2e.sh \
+  --artifact-dir ~/Desktop/whisper \
+  --env-name whisper-example \
+  --clone-et \
+  --create-env \
+  --setup-env \
+  --export \
+  --build \
+  --run --audio-path ~/Desktop/audio.wav
+```
+
+This will automatically:
+1. Setup the environment:
+  - Clone the executorch repo
+  - Create a conda environment named `whisper-example`
+  - Install all dependencies
+2. Export the Whisper model to the `~/Desktop/whisper` directory
+3. Build the Whisper Metal runner
+4. Run inference on `~/Desktop/whisper/audio.wav`
+
+### Step-by-Step Manual Process
+
+If you prefer to run each step individually, follow these steps:
+
+#### Step 1: Set up the environment
+
+```bash
+git clone git@github.com:pytorch/executorch.git
+cd executorch
+conda create -yn <env_name> python=3.11
+conda activate <env_name>
+/path/to/metal/setup_python_env.sh
+```
+
+#### Step 2: Export the Model
+
+```bash
+/path/to/metal/whisper/export.sh <artifact_dir>
+```
+
+**Arguments:**
+- `<artifact_dir>` - Directory to store exported model files (e.g., `~/Desktop/whisper`)
+
+This will:
+- Download the Whisper model
+- Export it to ExecuTorch format with Metal optimizations
+- Save model files (`.pte`), metadata, and preprocessor to the specified directory
+
+#### Step 3: Build the Whisper Metal Runner
+
+```bash
+/path/to/metal/whisper/build.sh
+```
+
+#### Step 4: Run Inference
+
+```bash
+/path/to/metal/whisper/run.sh <audio_path> <artifact_dir>
+```
+
+**Arguments:**
+- `<audio_path>` - Path to your audio file (e.g., `/path/to/audio.wav`)
+- `<artifact_dir>` - Directory containing exported model files (e.g., `~/Desktop/whisper`)
+
+This will:
+- Validate that all required model files exist
+- Load the model and preprocessor
+- Run inference on the provided audio
+- Display timing information

--- a/metal/whisper/build.sh
+++ b/metal/whisper/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake --preset llm \
+              -DEXECUTORCH_BUILD_METAL=ON \
+              -DCMAKE_INSTALL_PREFIX=cmake-out \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DEXECUTORCH_ENABLE_LOGGING=ON \
+              -DEXECUTORCH_LOG_LEVEL=Info \
+              -Bcmake-out -S.
+
+cmake --build cmake-out -j16 --target install --config Release
+
+cmake -DEXECUTORCH_BUILD_METAL=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -Sexamples/models/whisper \
+      -Bcmake-out/examples/models/whisper/
+
+cmake --build cmake-out/examples/models/whisper --target whisper_runner --config Release

--- a/metal/whisper/e2e.sh
+++ b/metal/whisper/e2e.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+# Initialize variables
+CLONE=false
+CREATE_ENV=false
+SETUP_ENV=false
+EXPORT=false
+BUILD=false
+RUN=false
+EXECUTORCH_PATH=""
+ARTIFACT_DIR=""
+ENV_NAME=""
+AUDIO_PATH=""
+
+echo "Current script path: $(realpath "$0")"
+SCRIPT_DIR="$(realpath "$(dirname "$(realpath "$0")")")"
+echo "Scripts directory: $SCRIPT_DIR"
+SCRIPT_PARENT="$(realpath "$SCRIPT_DIR/..")"
+echo "Scripts parent: $SCRIPT_PARENT"
+
+# Function to display usage
+usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  --artifact-dir DIR     Path to the directory were artifacts will be placed (required)"
+  echo "  --env-name NAME        Name of the conda environment (required)"
+  echo "  --clone-et             Clone the executorch repository"
+  echo "  --executorch-path DIR  Path to the executorch repo (required if --clone-et not used)"
+  echo "  --create-env           Create the Python environment"
+  echo "  --setup-env            Set up the Python environment"
+  echo "  --export               Export the Whisper model"
+  echo "  --build                Build the Whisper runner"
+  echo "  --audio-path PATH      Path to the input audio file"
+  echo "  --run                  Run the Whisper model"
+  echo "  -h, --help             Display this help message"
+  echo ""
+  echo "Example:"
+  echo "  $0 --env-name metal-backend --setup-env --export --build --audio-path audio.wav --run"
+  exit 1
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --clone-et)
+      CLONE=true
+      shift
+      ;;
+    --executorch-path)
+      EXECUTORCH_PATH="$2"
+      shift 2
+      ;;
+    --env-name)
+      ENV_NAME="$2"
+      shift 2
+      ;;
+    --create-env)
+      CREATE_ENV=true
+      shift
+      ;;
+    --setup-env)
+      SETUP_ENV=true
+      shift
+      ;;
+    --artifact-dir)
+      ARTIFACT_DIR="$2"
+      shift 2
+      ;;
+    --export)
+      EXPORT=true
+      shift
+      ;;
+    --build)
+      BUILD=true
+      shift
+      ;;
+    --audio-path)
+      AUDIO_PATH="$2"
+      shift 2
+      ;;
+    --run)
+      RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Error: Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+# Validate required options
+if [ -z "$ARTIFACT_DIR" ]; then
+  echo "Error: --artifact-dir is required"
+  exit 1
+fi
+
+if [ -z "$ENV_NAME" ]; then
+  echo "Error: --env-name is required"
+  exit 1
+fi
+
+if [ "$CLONE" = false ]; then
+  if [ -z "$EXECUTORCH_PATH" ]; then
+    echo "Error: --executorch-path is required when not using --clone"
+    exit 1
+  fi
+fi
+
+if [ "$RUN" = true ]; then
+  if [ -z "$AUDIO_PATH" ]; then
+    echo "Error: --audio-path is required when using --run"
+    exit 1
+  fi
+fi
+
+# Clone and cd into executorch if --clone flag is set
+if [ "$CLONE" = true ]; then
+  if [ -n "$EXECUTORCH_PATH" ]; then
+    echo "Error: --executorch-path should not be provided when using --clone"
+    exit 1
+  fi
+
+  mkdir -p "$ARTIFACT_DIR"
+  cd "$ARTIFACT_DIR"
+  echo "Cloning executorch repository..."
+  git clone git@github.com:pytorch/executorch.git
+
+  # Set EXECUTORCH_PATH to ARTIFACT_DIR/executorch after cloning
+  EXECUTORCH_PATH="${ARTIFACT_DIR}/executorch"
+fi
+
+cd "$EXECUTORCH_PATH"
+
+# Execute create-env
+if [ "$CREATE_ENV" = true ]; then
+  echo "Creating the Python environment $ENV_NAME ..."
+  conda create -yn "$ENV_NAME" python=3.11
+fi
+
+# Execute setup-env
+if [ "$SETUP_ENV" = true ]; then
+  echo "Setting up Python environment $ENV_NAME ..."
+  echo " - Script: $SCRIPT_PARENT/setup_python_env.sh"
+  conda run -n "$ENV_NAME" "$SCRIPT_PARENT/setup_python_env.sh"
+
+fi
+
+# Execute export
+if [ "$EXPORT" = true ]; then
+  echo "Exporting Whisper model to $ARTIFACT_DIR ..."
+  echo " - Script: $SCRIPT_DIR/export.sh"
+  conda run -n "$ENV_NAME" "$SCRIPT_DIR/export.sh" "$ARTIFACT_DIR"
+fi
+
+# Execute build
+if [ "$BUILD" = true ]; then
+  echo "Building Whisper runner ..."
+  echo " - Script: $SCRIPT_DIR/build.sh"
+  conda run -n "$ENV_NAME" "$SCRIPT_DIR/build.sh"
+fi
+
+# Execute run
+if [ "$RUN" = true ]; then
+  echo "Running Whisper with audio: $AUDIO_PATH"
+  echo " - Script: $SCRIPT_DIR/run.sh"
+  "$SCRIPT_DIR/run.sh" "$AUDIO_PATH" "$ARTIFACT_DIR"
+fi
+
+echo "Done!"

--- a/metal/whisper/export.sh
+++ b/metal/whisper/export.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+ARTIFACT_DIR="$1"
+
+if [ -z "$ARTIFACT_DIR" ]; then
+    echo "Error: ARTIFACT_DIR argument not provided."
+    echo "Usage: $0 <ARTIFACT_DIR>"
+    exit 1
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+
+optimum-cli export executorch \
+            --model "openai/whisper-large-v3-turbo" \
+            --task "automatic-speech-recognition" \
+            --recipe "metal" \
+            --dtype bfloat16 \
+            --output_dir "$ARTIFACT_DIR"
+
+python -m executorch.extension.audio.mel_spectrogram \
+            --feature_size 128 \
+            --stack_output \
+            --max_audio_len 300 \
+            --output_file "$ARTIFACT_DIR"/whisper_preprocessor.pte
+
+TOKENIZER_URL="https://huggingface.co/openai/whisper-large-v3-turbo/resolve/main"
+
+curl -L $TOKENIZER_URL/tokenizer.json -o $ARTIFACT_DIR/tokenizer.json
+curl -L $TOKENIZER_URL/tokenizer_config.json -o $ARTIFACT_DIR/tokenizer_config.json
+curl -L $TOKENIZER_URL/special_tokens_map.json -o $ARTIFACT_DIR/special_tokens_map.json

--- a/metal/whisper/run.sh
+++ b/metal/whisper/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Error: Input audio path and artifact directory path must be provided as arguments"
+  echo "Usage: $0 <input_audio_path> <artifact_dir>"
+  echo ""
+  echo "Arguments:"
+  echo "  <input_audio_path>  Path to the input audio file"
+  echo "  <artifact_dir>      Path to directory containing model files"
+  exit 1
+fi
+
+INPUT_AUDIO_PATH="$1"
+ARTIFACT_DIR="$2"
+
+# Check if input audio file exists
+if [ ! -f "$INPUT_AUDIO_PATH" ]; then
+  echo "Error: Input audio file not found: $INPUT_AUDIO_PATH"
+  exit 1
+fi
+
+# Check if directory exists
+if [ ! -d "$ARTIFACT_DIR" ]; then
+  echo "Error: Directory not found: $ARTIFACT_DIR"
+  exit 1
+fi
+
+# Check for required files
+REQUIRED_FILES=("model.pte" "aoti_metal_blob.ptd" "whisper_preprocessor.pte")
+for file in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$ARTIFACT_DIR/$file" ]; then
+    echo "Error: Required file not found: $ARTIFACT_DIR/$file"
+    exit 1
+  fi
+done
+
+/usr/bin/time -l ./cmake-out/examples/models/whisper/whisper_runner \
+      --model_path "$ARTIFACT_DIR"/model.pte \
+      --data_path "$ARTIFACT_DIR"/aoti_metal_blob.ptd \
+      --tokenizer_path "$ARTIFACT_DIR"/ \
+      --audio_path "$INPUT_AUDIO_PATH" \
+      --processor_path "$ARTIFACT_DIR"/whisper_preprocessor.pte \
+      --model_name "large-v3-turbo" \
+      --temperature 0


### PR DESCRIPTION
This PR adds end-to-end examples for running Voxtral and Whisper on ExecuTorch Metal backend

**Voxtral:**
```bash
metal/voxtral/e2e.sh \
  --artifact-dir <artifact_dir> \
  --env-name <env_name> \
  --clone-et \
  --create-env \
  --setup-env \
  --export \
  --build \
  --run --audio-path <audio_path>
```

**Whisper:**
```bash
metal/whisper/e2e.sh \
  --artifact-dir <artifact_dir> \
  --env-name <env_name> \
  --clone-et \
  --create-env \
  --setup-env \
  --export \
  --build \
  --run --audio-path <audio_path>
```
