### PR TITLE
Temporary fix for .generate() bug affecting LLM context appending

### DIFF
--- a/llm/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
+++ b/llm/android/LlamaDemo/app/src/main/java/com/example/executorchllamademo/MainActivity.java
@@ -845,6 +845,7 @@ public class MainActivity extends AppCompatActivity implements Runnable, LlmCall
                           onModelRunStopped();
                         }
                       });
+                  mModule.resetContext();
                   ETLogging.getInstance().log("Inference completed");
                 }
               };


### PR DESCRIPTION
Somehow the mModule.generate() function seems to append context incorrectly, for example:
```
user : "Who are you ?"
assistant : "I am an Artificial ... "
user : "what is 2 +2?"
assistant : "I am an AI ..."
user : "what is 3+3?"
assistant : "I am an LLM, you can call me Llama ... "
```

So I reset the context as temporary fix