### PR TITLE
Update lora example

### DIFF
--- a/program-data-separation/config/qwen3_06b_config.json
+++ b/program-data-separation/config/qwen3_06b_config.json
@@ -1,0 +1,17 @@
+{
+  "dim": 1024,
+  "ffn_dim_multiplier": 1,
+  "hidden_dim": 3072,
+  "n_heads": 16,
+  "head_dim": 128,
+  "n_kv_heads": 8,
+  "n_layers": 28,
+  "norm_eps": 1e-06,
+  "rope_theta": 1000000.0,
+  "use_scaled_rope": false,
+  "vocab_size": 151936,
+  "use_hf_rope": true,
+  "attention_qkv_bias": false,
+  "use_qk_norm": true,
+  "qk_norm_before_rope": true
+}

--- a/program-data-separation/config/qwen3_xnnpack.yaml
+++ b/program-data-separation/config/qwen3_xnnpack.yaml
@@ -1,0 +1,18 @@
+base:
+  model_class: "qwen3_0_6b"
+  params: "config/qwen3_06b_config.json"
+  metadata: '{"get_bos_id": 151644, "get_eos_ids":[151645]}'
+
+model:
+  use_kv_cache: True
+  use_sdpa_with_kv_cache: True
+  dtype_override: fp32
+
+export:
+  max_seq_length: 2048
+  max_context_length: 2048
+
+backend:
+  xnnpack:
+    enabled: True
+    extended_ops: True

--- a/program-data-separation/cpp/lora_example/build_example.sh
+++ b/program-data-separation/cpp/lora_example/build_example.sh
@@ -7,7 +7,10 @@ mkdir -p build
 cd build
 
 # Configure CMake
-cmake -DCMAKE_BUILD_TYPE=Release -DEXECUTORCH_BUILD_LORA_DEMO=True -DEXECUTORCH_XNNPACK_ENABLE_WEIGHT_CACHE=True ../..
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DEXECUTORCH_BUILD_LORA_DEMO=True \
+      -DEXECUTORCH_XNNPACK_ENABLE_WEIGHT_CACHE=True \
+      ../..
 
 # Build the project
 cmake --build . -j$(nproc)


### PR DESCRIPTION
Use qwen0.6b model trained on maths with unsloth.

Replace the existing llama example (requires auth token to download llama weights) for something easier to follow and get started with.

Keep the old demo video, which I think was pretty nice.