### PR TITLE
Remove deprecated MPS backend test from iOS demo

### DIFF
--- a/mv3/apple/ExecuTorchDemo/ExecuTorchDemo/Sources/MobileNet/Test/MobileNetClassifierTest.swift
+++ b/mv3/apple/ExecuTorchDemo/ExecuTorchDemo/Sources/MobileNet/Test/MobileNetClassifierTest.swift
@@ -21,10 +21,6 @@ final class MobileNetClassifierTest: XCTestCase {
     try run(model: "mv3_coreml_all")
   }
 
-  func testV3WithMPSBackend() throws {
-    try run(model: "mv3_mps_float16")
-  }
-
   func testV3WithXNNPACKBackend() throws {
     try run(model: "mv3_xnnpack_fp32")
   }


### PR DESCRIPTION
The MPS backend was deprecated for removal in ExecuTorch 1.4 by pytorch/executorch#18425, and the iOS demo's `testV3WithMPSBackend()` has been intermittently failing on the `macos-14-xlarge` runner pool since around the same time. The failure pattern (3 isolated reds sandwiched between many greens, fp16-only model, tight confidence thresholds shared with the fp32 backends) points at iOS-simulator MPS shader precision drift rather than an executorch regression — the MPS runtime code in pytorch/executorch hasn't materially changed since the deprecation.

Drop the test rather than chase numerical noise on a backend that is slated for removal. CoreML is the recommended replacement for iOS GPU acceleration per the deprecation guidance, and `testV3WithCoreMLBackend` already exercises that path on the same model.

A companion change to pytorch/executorch's `.ci/scripts/test_ios_ci.sh` removes the matching `mps_example.py` export step so the build doesn't produce an unused `.pte`.

Authored with Claude Code.